### PR TITLE
fix loop bug of nthi.Hash()

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ func main() {
         log.Fatal(err)
     }
     // collect the hashes by ranging over the hash channel produced by the Hash method
-    for hash := range hasher.Hash() {
+    canonical := true
+    for hash := range hasher.Hash(canonical) {
         log.Println(hash)
     }
 }

--- a/ntHash.go
+++ b/ntHash.go
@@ -169,26 +169,28 @@ func (nthi *nthi) Hash(canonical bool) <-chan uint64 {
 	hashChan := make(chan uint64)
 	go func() {
 		defer close(hashChan)
-		if nthi.currentIdx >= nthi.maxIdx {
-			return
-		}
-		if nthi.currentIdx != 0 {
-			prevBase := (*nthi.seq)[nthi.currentIdx-1]
-			endBase := (*nthi.seq)[nthi.currentIdx+nthi.k-1]
-			// alg 3. of ntHash paper
-			nthi.fh = roL(nthi.fh, 1)
-			nthi.fh ^= roL(hash(prevBase), nthi.k)
-			nthi.fh ^= hash(endBase)
-			nthi.rh = roR(nthi.rh, 1)
-			nthi.rh ^= roR(rcHash(prevBase), 1)
-			nthi.rh ^= roL(rcHash(endBase), nthi.k-1)
-		}
-		nthi.currentIdx++
-		// return the canonical ntHash
-		if canonical {
-			hashChan <- nthi.getCanonical()
-		} else {
-			hashChan <- nthi.fh
+		for {
+			if nthi.currentIdx >= nthi.maxIdx {
+				return
+			}
+			if nthi.currentIdx != 0 {
+				prevBase := (*nthi.seq)[nthi.currentIdx-1]
+				endBase := (*nthi.seq)[nthi.currentIdx+nthi.k-1]
+				// alg 3. of ntHash paper
+				nthi.fh = roL(nthi.fh, 1)
+				nthi.fh ^= roL(hash(prevBase), nthi.k)
+				nthi.fh ^= hash(endBase)
+				nthi.rh = roR(nthi.rh, 1)
+				nthi.rh ^= roR(rcHash(prevBase), 1)
+				nthi.rh ^= roL(rcHash(endBase), nthi.k-1)
+			}
+			nthi.currentIdx++
+			// return the canonical ntHash
+			if canonical {
+				hashChan <- nthi.getCanonical()
+			} else {
+				hashChan <- nthi.fh
+			}
 		}
 	}()
 	return hashChan

--- a/ntHash_test.go
+++ b/ntHash_test.go
@@ -128,6 +128,9 @@ func TestHash(t *testing.T) {
 			t.Fatal("unexpected output from nthi")
 		}
 	}
+	if counter != 3 {
+		t.Fatal("wrong iteration")
+	}
 }
 
 // run a benchmark of ntHash


### PR DESCRIPTION
Hi @will-rowe , this PR fixes the bug of method:

    func (nthi *nthi) Hash(canonical bool) <-chan uint64 {

You forgot the loop, and the test code didn't check the iterating times either.

Example code is updated too.
